### PR TITLE
this adds option to configure S3 style access (path-style URLs or vir…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -159,6 +159,32 @@ S3 connectors will expect to find environment properties `AWS_ACCESS_KEY_ID` and
 They will also accept `AWS_REGION` and `AWS_ENDPOINT` environment properties—however they are not required.
 If `AWS_ENDPOINT` is set, `AWS_REGION` has to be set too.
 
+S3 currently supports two different addressing models: path-style and virtual-hosted style (https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAPI.html).
+
+Esop supports different S3 providers and applies the following default addressing models.
+
+.default settings per provider
+|===
+|provider |addressing model
+
+|AWS
+|virtual
+
+|Ceph
+|virtual
+
+|Minio
+|path
+
+|Oracle
+|path
+|===
+
+Providing the AWS_ENABLE_PATH_STYLE_ACCESS environment variable with `true` or `false` overrides this default setting. Note that this applies to each provider, except when running in Kubernetes.
+
+|provider|model|
+|Minio|path|
+
 The communication with S3 might be insecure, this is controlled by `--insecure-http` flag on the command line. By default,
 it uses HTTPS.
 

--- a/src/main/java/com/instaclustr/esop/s3/TransferManagerFactory.java
+++ b/src/main/java/com/instaclustr/esop/s3/TransferManagerFactory.java
@@ -2,6 +2,7 @@ package com.instaclustr.esop.s3;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.instaclustr.kubernetes.KubernetesHelper.isRunningAsClient;
+import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
 
 import java.util.Map;
@@ -67,7 +68,9 @@ public class TransferManagerFactory {
             builder.withRegion(Regions.fromName(s3Conf.awsRegion.toLowerCase()));
         }
 
-        if (enablePathStyleAccess) {
+        if(s3Conf.awsPathStyleAccessEnabled != null) {
+            builder.withPathStyleAccessEnabled(s3Conf.awsPathStyleAccessEnabled);
+        } else if(enablePathStyleAccess) {
             // for being able to work with Oracle "s3"
             builder.enablePathStyleAccess();
         }
@@ -205,6 +208,8 @@ public class TransferManagerFactory {
         s3Configuration.awsEndpoint = System.getenv("AWS_ENDPOINT");
         s3Configuration.awsAccessKeyId = System.getenv("AWS_ACCESS_KEY_ID");
         s3Configuration.awsSecretKey = System.getenv("AWS_SECRET_KEY");
+        String awsEnablePathStyleAccess = System.getenv("AWS_ENABLE_PATH_STYLE_ACCESS");
+        s3Configuration.awsPathStyleAccessEnabled = awsEnablePathStyleAccess != null ? parseBoolean(awsEnablePathStyleAccess) : null;
 
         // accesskeyid and awssecretkey will be taken from normal configuration mechanism in ~/.aws/ ...
         // s3Configuration.awsAccessKeyId = System.getenv("AWS_ACCESS_KEY_ID");
@@ -222,10 +227,10 @@ public class TransferManagerFactory {
     }
 
     public static final class S3Configuration {
-
         public String awsRegion;
         public String awsEndpoint;
         public String awsAccessKeyId;
         public String awsSecretKey;
+        public Boolean awsPathStyleAccessEnabled;
     }
 }


### PR DESCRIPTION
this adds option to configure S3 style access (path-style URLs or virtual hosted-style URLs) with the environment variable AWS_ENABLE_PATH_STYLE_ACCESS.

Note that when this variable isn't provided the default hard-coded value is used depending on the module. With this environment variable one is able to override the default value. https://github.com/instaclustr/esop/issues/53 provides some more context.

Besides this option the Ceph module is updated to use the builder in configuring/providing AmazonS3.