### PR TITLE
snapshot parsing parses just one snapshot, not all

### DIFF
--- a/src/main/java/com/instaclustr/esop/impl/backup/coordination/BaseBackupOperationCoordinator.java
+++ b/src/main/java/com/instaclustr/esop/impl/backup/coordination/BaseBackupOperationCoordinator.java
@@ -111,8 +111,7 @@ public class BaseBackupOperationCoordinator extends OperationCoordinator<BackupO
                                       cassandraVersionProvider).run0();
 
             Snapshots.hashSpec = hashSpec;
-            final Snapshots snapshots = Snapshots.parse(request.cassandraDirectory.resolve("data"));
-
+            final Snapshots snapshots = Snapshots.parse(request.cassandraDirectory.resolve("data"), request.snapshotTag);
             final Optional<Snapshot> snapshot = snapshots.get(request.snapshotTag);
 
             if (!snapshot.isPresent()) {


### PR DESCRIPTION
It is not necessary to parse all snapshots a node has. We just need to parse the one which we just took. This will enable parallel backups possible / hassle free as one backup might clean a snapshot the other backup would try to parse but it is deleted already, which happens to fail.

solves https://github.com/instaclustr/esop/issues/55