### PR TITLE
Fix ESOP crash when parsing manifest entries with zero-size files and missing localFile reference

### DIFF
--- a/src/main/java/com/instaclustr/esop/impl/ManifestEntry.java
+++ b/src/main/java/com/instaclustr/esop/impl/ManifestEntry.java
@@ -86,7 +86,7 @@ public class ManifestEntry implements Cloneable {
 
         try {
             if (size == 0) {
-                if (Files.exists(localFile)) {
+                if (localFile != null && Files.exists(localFile)) {
                     this.size = Files.size(localFile);
                 }
             } else {


### PR DESCRIPTION
**Description**

This PR fixes a runtime error occurring during snapshot listing or restoration when ManifestEntry contains an entry with "size": 0 and no corresponding "localFile" field.

**Problem**

If a snapshot manifest includes entries like:

```
{
  "objectKey": "data/attach/attach_by_user.../nb-714-big-SAI+aa+GroupComplete.db",
  "type": "FILE",
  "size": 0,
  "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
}
```

and the localFile field is null, ManifestEntry throws a NullPointerException or IllegalStateException when trying to determine file size or existence.

**Fix**

This patch ensures that size validation logic is skipped or gracefully handled when localFile is null, preventing crashes in backup listing or restore phases.