### PR TITLE
feat: add --gcp-uniform-bucket-level-access flag to skip ACLs

### DIFF
--- a/src/main/java/com/instaclustr/esop/impl/backup/BackupCommitLogsOperationRequest.java
+++ b/src/main/java/com/instaclustr/esop/impl/backup/BackupCommitLogsOperationRequest.java
@@ -74,7 +74,8 @@ public class BackupCommitLogsOperationRequest extends BaseBackupOperationRequest
                                             @JsonProperty("proxySettings") final ProxySettings proxySettings,
                                             @JsonProperty("retry") final RetrySpec retry,
                                             @JsonProperty("skipRefreshing") final boolean skipRefreshing,
-                                            @JsonProperty("kmsKeyId") final String kmsKeyId) {
+                                            @JsonProperty("kmsKeyId") final String kmsKeyId,
+                                            @JsonProperty("gcpUniformBucketLevelAccess") final boolean gcpUniformBucketLevelAccess) {
         super(storageLocation,
               duration,
               bandwidth,
@@ -87,7 +88,8 @@ public class BackupCommitLogsOperationRequest extends BaseBackupOperationRequest
               retry,
               skipRefreshing,
               null,
-              kmsKeyId);
+              kmsKeyId,
+              gcpUniformBucketLevelAccess);
         this.type = "commitlog-backup";
         this.commitLogArchiveOverride = commitLogArchiveOverride;
         this.commitLog = commitLog;

--- a/src/main/java/com/instaclustr/esop/impl/backup/BackupOperation.java
+++ b/src/main/java/com/instaclustr/esop/impl/backup/BackupOperation.java
@@ -91,7 +91,8 @@ public class BackupOperation extends Operation<BackupOperationRequest> implement
                             @JsonSerialize(using = ListPathSerializer.class)
                             @JsonDeserialize(contentUsing = PathDeserializer.class)
                             @JsonProperty("dataDirs") final List<Path> dataDirs,
-                            @JsonProperty("kmsKeyId") final String kmsKeyId) {
+                            @JsonProperty("kmsKeyId") final String kmsKeyId,
+                            @JsonProperty("gcpUniformBucketLevelAccess") final boolean gcpUniformBucketLevelAccess) {
         super(type, id, creationTime, state, errors, progress, startTime, new BackupOperationRequest(type,
                                                                                                      storageLocation,
                                                                                                      duration,
@@ -112,7 +113,8 @@ public class BackupOperation extends Operation<BackupOperationRequest> implement
                                                                                                      retry,
                                                                                                      skipRefreshing,
                                                                                                      dataDirs,
-                                                                                                     kmsKeyId));
+                                                                                                     kmsKeyId,
+                                                                                                     gcpUniformBucketLevelAccess));
         coordinator = null;
         storageProviders = null;
     }

--- a/src/main/java/com/instaclustr/esop/impl/backup/BackupOperationRequest.java
+++ b/src/main/java/com/instaclustr/esop/impl/backup/BackupOperationRequest.java
@@ -101,7 +101,8 @@ public class BackupOperationRequest extends BaseBackupOperationRequest {
                                   @JsonSerialize(using = ListPathSerializer.class)
                                   @JsonDeserialize(contentUsing = PathDeserializer.class)
                                   @JsonProperty("dataDirs") final List<Path> dataDirs,
-                                  @JsonProperty("kmsKeyId") final String kmsKeyId) {
+                                  @JsonProperty("kmsKeyId") final String kmsKeyId,
+                                  @JsonProperty("gcpUniformBucketLevelAccess") final boolean gcpUniformBucketLevelAccess) {
         super(storageLocation,
               duration,
               bandwidth,
@@ -114,7 +115,8 @@ public class BackupOperationRequest extends BaseBackupOperationRequest {
               retry,
               skipRefreshing,
               dataDirs,
-              kmsKeyId);
+              kmsKeyId,
+              gcpUniformBucketLevelAccess);
         this.entities = entities == null ? DatabaseEntities.empty() : entities;
         this.snapshotTag = snapshotTag == null ? format("autosnap-%d", MILLISECONDS.toSeconds(currentTimeMillis())) : snapshotTag;
         this.globalRequest = globalRequest;
@@ -148,6 +150,7 @@ public class BackupOperationRequest extends BaseBackupOperationRequest {
             .add("retry", retry)
             .add("skipRefreshing", skipRefreshing)
             .add("kmsKeyId", kmsKeyId)
+            .add("gcpUniformBucketLevelAccess", gcpUniformBucketLevelAccess)
             .toString();
     }
 

--- a/src/main/java/com/instaclustr/esop/impl/backup/BaseBackupOperationRequest.java
+++ b/src/main/java/com/instaclustr/esop/impl/backup/BaseBackupOperationRequest.java
@@ -64,6 +64,11 @@ public class BaseBackupOperationRequest extends AbstractOperationRequest {
             + "based on which a respective local file will be upload or not, defaults to false, does not work with s3.")
     public boolean skipRefreshing;
 
+    @JsonProperty("gcpUniformBucketLevelAccess")
+    @Option(names = "--gcp-uniform-bucket-level-access",
+        description = "For GCP storage, skip setting ACLs when bucket has uniform bucket-level access enabled. Defaults to false.")
+    public boolean gcpUniformBucketLevelAccess;
+
     public BaseBackupOperationRequest() {
         // for picocli
         if (metadataDirective == null) {
@@ -83,7 +88,8 @@ public class BaseBackupOperationRequest extends AbstractOperationRequest {
                                       final RetrySpec retrySpec,
                                       final boolean skipRefreshing,
                                       final List<Path> dataDirs,
-                                      final String kmsKeyId) {
+                                      final String kmsKeyId,
+                                      final boolean gcpUniformBucketLevelAccess) {
         super(storageLocation, insecure, skipBucketVerification, proxySettings, retrySpec, concurrentConnections, kmsKeyId);
         this.duration = duration;
         this.bandwidth = bandwidth;
@@ -91,5 +97,6 @@ public class BaseBackupOperationRequest extends AbstractOperationRequest {
         this.createMissingBucket = createMissingBucket;
         this.skipRefreshing = skipRefreshing;
         this.dataDirs = dataDirs;
+        this.gcpUniformBucketLevelAccess = gcpUniformBucketLevelAccess;
     }
 }

--- a/src/test/java/com/instaclustr/esop/backup/embedded/UploadTrackerTest.java
+++ b/src/test/java/com/instaclustr/esop/backup/embedded/UploadTrackerTest.java
@@ -242,27 +242,28 @@ public class UploadTrackerTest extends AbstractBackupTest {
                                                                        final String entities,
                                                                        final List<Path> dataDirs) throws Exception {
         return new BackupOperationRequest(
-        "backup",
-        new StorageLocation.StorageLocationTypeConverter().convert(getStorageLocation()),
-        null,
-        null,
-        null,
-        null,
-        DatabaseEntities.parse(entities),
-        snapshotName,
-        false,
-        null,
-        null, // timeout
-        false,
-        false,
-        false,
-        null,
-        false,
-        null, // proxy settings
-        null, // retry
-        false, // skipRefreshing
-        dataDirs,
-        null
+                "backup",
+                new StorageLocation.StorageLocationTypeConverter().convert(getStorageLocation()),
+                null,
+                null,
+                null,
+                null,
+                DatabaseEntities.parse(entities),
+                snapshotName,
+                false,
+                null,
+                null, // timeout
+                false,
+                false,
+                false,
+                null,
+                false,
+                null, // proxy settings
+                null, // retry
+                false, // skipRefreshing
+                dataDirs,
+                null,
+                false
         );
     }
 


### PR DESCRIPTION
Add a configuration flag to conditionally skip setting predefined ACLs on GCS uploads when buckets have uniform bucket-level access enabled.

- Add gcpUniformBucketLevelAccess boolean field to BaseBackupOperationRequest
- Update GCPBackuper to conditionally apply BUCKET_OWNER_FULL_CONTROL ACL
- Support flag in both regular backups and commit log backups
- Maintain backward compatibility (defaults to false)

Fixes #89