### PR TITLE
Bump software.amazon.awssdk:bom to 2.46.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.1.8]
 
+### Added
+
 - Allow configuration of max block blob size for Azure module (#114)
+
+### Changed
+
+- Bumped software.amazon.awssdk:bom to 2.46.6
 
 ## [4.1.7]
 

--- a/s3/pom.xml
+++ b/s3/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <maven.surefire.plugin.version>3.1.2</maven.surefire.plugin.version>
-        <aws-java-sdk.version>2.44.7</aws-java-sdk.version>
+        <aws-java-sdk.version>2.46.6</aws-java-sdk.version>
         <s3.encryption.client.version>4.0.0</s3.encryption.client.version>
         <bouncy.castle.version>1.78.1</bouncy.castle.version>
         <skip.packages>false</skip.packages>


### PR DESCRIPTION
Addresses CVE-2026-47244, CVE-2026-44249, and CVE-2026-45416 vulnarabilities