### PR TITLE
Bump jackson-bom and logback-core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,7 +27,7 @@
         <jackson.bom.version>2.21.5</jackson.bom.version>
 
         <slf4j.version>2.0.17</slf4j.version>
-        <logback.version>1.5.25</logback.version>
+        <logback.version>1.5.35</logback.version>
 
         <git.commit.id/>
         <git.build.time/>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@
         <apache.commons.lang3>3.19.0</apache.commons.lang3>
         <commons-io.version>2.20.0</commons-io.version>
         <awaitility.version>3.1.6</awaitility.version>
-        <jackson.bom.version>2.21.4</jackson.bom.version>
+        <jackson.bom.version>2.21.5</jackson.bom.version>
 
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.25</logback.version>


### PR DESCRIPTION
Bumps dependencies to address vulnerabilities:
- ch.qos.logback:logback-core to 1.5.35 (CVE-2026-10532)
- com.fasterxml.jackson:jackson-bom to 2.21.5 (CVE-2026-54515)

Ticket: INS-42878